### PR TITLE
Replace androidx

### DIFF
--- a/android/src/main/java/io/amarcruz/photoview/ImageEvent.java
+++ b/android/src/main/java/io/amarcruz/photoview/ImageEvent.java
@@ -1,6 +1,6 @@
 package io.amarcruz.photoview;
 
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.RCTEventEmitter;

--- a/android/src/main/java/io/amarcruz/photoview/PhotoView.java
+++ b/android/src/main/java/io/amarcruz/photoview/PhotoView.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.drawee.backends.pipeline.PipelineDraweeControllerBuilder;
 import com.facebook.drawee.controller.BaseControllerListener;


### PR DESCRIPTION
`./gradlew bundleRelease`でエラーが出たので修正。

```
./gradlew bundleProductionRelease

> Task :react-native-photo-view-ex:compileReleaseJavaWithJavac FAILED
/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/ImageEvent.java:3: エラー: パッケージandroid.support.annotationは存在しません
import android.support.annotation.IntDef;
                                 ^
/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/ImageEvent.java:12: エラー: シンボルを見つけられません
  @IntDef({ON_ERROR, ON_LOAD, ON_LOAD_END, ON_LOAD_START, ON_TAP, ON_VIEW_TAP, ON_SCALE})
   ^
  シンボル:   クラス IntDef
  場所: クラス ImageEvent
/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/PhotoView.java:7: エラー: パッケージandroid.support.annotationは存在しません
import android.support.annotation.NonNull;
                                 ^
/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/PhotoView.java:55: エラー: シンボルを見つけられません
                          @NonNull ResourceDrawableIdHelper resourceDrawableIdHelper) {
                           ^
  シンボル:   クラス NonNull
  場所: クラス PhotoView
/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/PhotoView.java:138: エラー: シンボルを見つけられません
    public void maybeUpdateView(@NonNull PipelineDraweeControllerBuilder builder) {
                                 ^
  シンボル:   クラス NonNull
  場所: クラス PhotoView
注意:/Users/hyuga/workspace/SassyAppRN/node_modules/react-native-photo-view-ex/android/src/main/java/io/amarcruz/photoview/ResourceDrawableIdHelper.javaは推奨されないAPIを使用またはオーバーライドしています。
注意:詳細は、-Xlint:deprecationオプションを指定して再コンパイルしてください。
エラー5個

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-photo-view-ex:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.5/userguide/command_line_interface.html#sec:command_line_warnings
```